### PR TITLE
Moved OH Item example to a code block to avoid MD reformatting of ":o…

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,4 +7,6 @@ www.thegreatgeekery.com
 3) MQTT topics is /device_name/switch
 
 Example openhab device:
+```
 Switch TestPlug "Test Eco Plug" (all) {mqtt=">[broker:/ecoplug/switch:command:on:ON],>[broker:/ecoplug/switch:command:off:OFF]
+```


### PR DESCRIPTION
…n:" in the line
